### PR TITLE
Handle non-string label values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ COPY . /build/
 
 WORKDIR /build
 
-ENV PHP_TEST_ARGS="-q"
+ENV TEST_PHP_ARGS="-q" \
+    REPORT_EXIT_STATUS=1
 
 RUN phpize && \
     ./configure --enable-stackdriver-trace && \

--- a/stackdriver_trace.c
+++ b/stackdriver_trace.c
@@ -569,7 +569,7 @@ static int stackdriver_labels_to_zval_array(HashTable *ht, zval *label_array)
     label_ht = Z_ARRVAL_P(label_array);
 
     ZEND_HASH_FOREACH_KEY_VAL(ht, idx, k, v) {
-        if (add_assoc_str(label_array, ZSTR_VAL(k), Z_STR_P(v)) != SUCCESS) {
+        if (add_assoc_zval(label_array, ZSTR_VAL(k), v) != SUCCESS) {
             php_prinf("failed to add_assoc_zval\n");
             return FAILURE;
         }

--- a/tests/non-string-labels-function-callback.phpt
+++ b/tests/non-string-labels-function-callback.phpt
@@ -7,7 +7,7 @@ function foo() {
     return 'bar';
 }
 stackdriver_trace_function('foo', function () {
-    return ['labels' => ['int' => 1, 'float' => 0.1]]
+    return ['labels' => ['int' => 1, 'float' => 0.1]];
 });
 
 foo();

--- a/tests/non-string-labels-function-callback.phpt
+++ b/tests/non-string-labels-function-callback.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Stackdriver Trace: Test setting labels
+--FILE--
+<?php
+
+function foo() {
+    return 'bar';
+}
+stackdriver_trace_function('foo', function () {
+    return ['labels' => ['int' => 1, 'float' => 0.1]]
+});
+
+foo();
+
+$traces = stackdriver_trace_list();
+echo "Number of traces: " . count($traces) . "\n";
+$span = $traces[0];
+print_r($span->labels());
+?>
+--EXPECT--
+Number of traces: 1
+Array
+(
+    [int] => 1
+    [float] => 0.1
+)

--- a/tests/non-string-labels-function.phpt
+++ b/tests/non-string-labels-function.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Stackdriver Trace: Test setting labels
+--FILE--
+<?php
+
+function foo() {
+    return 'bar';
+}
+stackdriver_trace_function('foo', ['labels' => ['int' => 1, 'float' => 0.1]]);
+
+foo();
+
+$traces = stackdriver_trace_list();
+echo "Number of traces: " . count($traces) . "\n";
+$span = $traces[0];
+print_r($span->labels());
+?>
+--EXPECT--
+Number of traces: 1
+Array
+(
+    [int] => 1
+    [float] => 0.1
+)

--- a/tests/non-string-labels-method-callback.phpt
+++ b/tests/non-string-labels-method-callback.phpt
@@ -3,16 +3,16 @@ Stackdriver Trace: Test setting labels
 --FILE--
 <?php
 
-class Foo
+class FooClass
 {
     function foo() {
         return 'bar';
     }
 }
-stackdriver_trace_method('Foo', 'foo', function () {
+stackdriver_trace_method('FooClass', 'foo', function () {
     return ['labels' => ['int' => 1, 'float' => 0.1]];
 });
-$foo = new Foo();
+$foo = new FooClass();
 $foo->foo();
 
 $traces = stackdriver_trace_list();

--- a/tests/non-string-labels-method-callback.phpt
+++ b/tests/non-string-labels-method-callback.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Stackdriver Trace: Test setting labels
+--FILE--
+<?php
+
+class Foo
+{
+    function foo() {
+        return 'bar';
+    }
+}
+stackdriver_trace_method('Foo', 'foo', function () {
+    return ['labels' => ['int' => 1, 'float' => 0.1]];
+});
+$foo = new Foo();
+$foo->foo();
+
+$traces = stackdriver_trace_list();
+echo "Number of traces: " . count($traces) . "\n";
+$span = $traces[0];
+print_r($span->labels());
+?>
+--EXPECT--
+Number of traces: 1
+Array
+(
+    [int] => 1
+    [float] => 0.1
+)

--- a/tests/non-string-labels-method.phpt
+++ b/tests/non-string-labels-method.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Stackdriver Trace: Test setting labels
+--FILE--
+<?php
+
+class Foo
+{
+    function foo() {
+        return 'bar';
+    }
+}
+stackdriver_trace_method('Foo', 'foo', ['labels' => ['int' => 1, 'float' => 0.1]]);
+$foo = new Foo();
+$foo->foo();
+
+$traces = stackdriver_trace_list();
+echo "Number of traces: " . count($traces) . "\n";
+$span = $traces[0];
+print_r($span->labels());
+?>
+--EXPECT--
+Number of traces: 1
+Array
+(
+    [int] => 1
+    [float] => 0.1
+)

--- a/tests/non-string-labels-method.phpt
+++ b/tests/non-string-labels-method.phpt
@@ -3,14 +3,14 @@ Stackdriver Trace: Test setting labels
 --FILE--
 <?php
 
-class Foo
+class FooClass
 {
     function foo() {
         return 'bar';
     }
 }
-stackdriver_trace_method('Foo', 'foo', ['labels' => ['int' => 1, 'float' => 0.1]]);
-$foo = new Foo();
+stackdriver_trace_method('FooClass', 'foo', ['labels' => ['int' => 1, 'float' => 0.1]]);
+$foo = new FooClass();
 $foo->foo();
 
 $traces = stackdriver_trace_list();

--- a/tests/non-string-labels.phpt
+++ b/tests/non-string-labels.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Stackdriver Trace: Test setting labels
+--FILE--
+<?php
+
+stackdriver_trace_begin('root', []);
+stackdriver_trace_add_label('int', 1);
+stackdriver_trace_begin('inner', []);
+stackdriver_trace_add_label('float', 0.1);
+stackdriver_trace_finish();
+stackdriver_trace_finish();
+
+$traces = stackdriver_trace_list();
+echo "Number of traces: " . count($traces) . "\n";
+$span = $traces[0];
+print_r($span->labels());
+
+$span2 = $traces[1];
+print_r($span2->labels());
+?>
+--EXPECT--
+Number of traces: 2
+Array
+(
+    [int] => 1
+)
+Array
+(
+    [float] => 0.1
+)


### PR DESCRIPTION
Previously, if you stored label values that were not strings, we would segfault when trying to return the label values. This is because we were assuming the values were strings, and adding them to the output array as a string. If the trace callback function returns labels which are not strings, return the zval instead and let the handler in PHP space coerce to a string (if necessary).