### PR TITLE
Windows support

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,0 +1,9 @@
+// $Id$
+// vim:ft=javascript
+
+ARG_ENABLE("stackdriver-trace", "stackdriver_trace support", "no");
+
+if (PHP_STACKDRIVER_TRACE != "no") {
+    EXTENSION('stackdriver_trace', 'stackdriver_trace.c stackdriver_trace_context.c stackdriver_trace_span.c');
+    AC_DEFINE('HAVE_STACKDRIVER_TRACE', 1);
+}

--- a/stackdriver_trace.c
+++ b/stackdriver_trace.c
@@ -586,7 +586,6 @@ static int stackdriver_labels_to_zval_array(HashTable *ht, zval *label_array)
 
     ZEND_HASH_FOREACH_KEY_VAL(ht, idx, k, v) {
         if (add_assoc_zval(label_array, ZSTR_VAL(k), v) != SUCCESS) {
-            php_prinf("failed to add_assoc_zval\n");
             return FAILURE;
         }
 

--- a/stackdriver_trace.c
+++ b/stackdriver_trace.c
@@ -365,7 +365,6 @@ PHP_FUNCTION(stackdriver_trace_finish)
 // Reset the list of spans and free any allocated memory used
 static void stackdriver_trace_clear(int reset TSRMLS_DC)
 {
-    int i;
     stackdriver_trace_span_t *span;
 
     // free memory for all captured spans
@@ -551,7 +550,6 @@ PHP_FUNCTION(stackdriver_trace_function)
  */
 PHP_FUNCTION(stackdriver_trace_method)
 {
-    zend_function *fe;
     zend_string *class_name, *function_name, *key;
     zval *handler, *copy;
 

--- a/stackdriver_trace.c
+++ b/stackdriver_trace.c
@@ -261,7 +261,7 @@ static stackdriver_trace_span_t *stackdriver_trace_begin(zend_string *function_n
         php_mt_srand(GENERATE_SEED());
     }
 #endif
-    span->span_id = php_mt_rand();
+    span->span_id = (php_mt_rand() >> 1);
 
     if (STACKDRIVER_TRACE_G(current_span)) {
         span->parent = STACKDRIVER_TRACE_G(current_span);

--- a/stackdriver_trace.c
+++ b/stackdriver_trace.c
@@ -15,7 +15,6 @@
  */
 
 #include "php_stackdriver_trace.h"
-#include <sys/time.h>
 #include "stackdriver_trace.h"
 #include "Zend/zend_compile.h"
 #include "Zend/zend_closures.h"
@@ -23,6 +22,12 @@
 
 #if PHP_VERSION_ID < 70100
 #include "standard/php_rand.h"
+#endif
+
+#ifdef _WIN32
+#include "win32/time.h"
+#else
+#include <sys/time.h>
 #endif
 
 // True global for storing the original zend_execute_ex function pointer


### PR DESCRIPTION
Allows the extension to compile on windows.

* adds a `config.w32` file
* removes variable length array declarations
* uses php's internal windows implementation of the c function `gettimeofday`